### PR TITLE
Wav files support for AudioConverter

### DIFF
--- a/YandexCloudApi/AudioConverter.cs
+++ b/YandexCloudApi/AudioConverter.cs
@@ -23,26 +23,23 @@ namespace YandexCloudApi
         /// <param name="pcmData">Raw PCM data without WAV header.</param>
         /// <param name="format">PCM data format.</param>
         /// <returns>Ogg container with OPUS-encoded stream.</returns>
-        public Task<byte[]> ConvertPcmToOpusAsync(byte[] pcmData, WaveFormat format)
+        public async Task<byte[]> ConvertPcmToOpusAsync(byte[] pcmData, WaveFormat format)
         {
-            return Task.Run(() =>
+            string pcmFile = Path.GetTempFileName();
+
+            try
             {
-                string pcmFile = Path.GetTempFileName();
-
-                try
+                using (var writer = new WaveFileWriter(pcmFile, format))
                 {
-                    using (var writer = new WaveFileWriter(pcmFile, format))
-                    {
-                        writer.Write(pcmData, 0, pcmData.Length);
-                    }
+                    writer.Write(pcmData, 0, pcmData.Length);
+                }
 
-                    return ConvertWavToOpusAsync(pcmFile);
-                }
-                finally
-                {
-                    File.Delete(pcmFile);
-                }
-            });
+                return await ConvertWavToOpusAsync(pcmFile);
+            }
+            finally
+            {
+                File.Delete(pcmFile);
+            }
         }
 
         /// <summary>

--- a/YandexCloudApi/AudioConverter.cs
+++ b/YandexCloudApi/AudioConverter.cs
@@ -23,23 +23,26 @@ namespace YandexCloudApi
         /// <param name="pcmData">Raw PCM data without WAV header.</param>
         /// <param name="format">PCM data format.</param>
         /// <returns>Ogg container with OPUS-encoded stream.</returns>
-        public async Task<byte[]> ConvertPcmToOpusAsync(byte[] pcmData, WaveFormat format)
+        public Task<byte[]> ConvertPcmToOpusAsync(byte[] pcmData, WaveFormat format)
         {
-            string pcmFile = Path.GetTempFileName();
-
-            try
+            return Task.Run(async () =>
             {
-                using (var writer = new WaveFileWriter(pcmFile, format))
+                string pcmFile = Path.GetTempFileName();
+
+                try
                 {
-                    writer.Write(pcmData, 0, pcmData.Length);
-                }
+                    using (var writer = new WaveFileWriter(pcmFile, format))
+                    {
+                        writer.Write(pcmData, 0, pcmData.Length);
+                    }
 
-                return await ConvertWavToOpusAsync(pcmFile);
-            }
-            finally
-            {
-                File.Delete(pcmFile);
-            }
+                    return await ConvertWavToOpusAsync(pcmFile);
+                }
+                finally
+                {
+                    File.Delete(pcmFile);
+                }
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Allow to convert wav file to OGG container.
Example:
var wavFile = @"c:\temp\MyAudio.wav";
var oggData = new AudioConverter().ConvertPcmToOpusAsync(wavFile).Result;